### PR TITLE
Deleted duplicate in Building Your Application

### DIFF
--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -197,7 +197,7 @@ configuration for your application.
 Building your application
 =========================
 
-You can now compile your your application. This step performs any binary
+You can now compile your application. This step performs any binary
 compilation that is necessary for your application to be executable on your
 target platform.
 


### PR DESCRIPTION
The first sentence in the section Building Your Application contains a duplicated word "your" as "You can now compile your your application".