### PR TITLE
Update Fedora WebKit dependency to webkit2gtk3

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -94,7 +94,7 @@ Next, install the additional dependencies needed for your operating system:
 
     .. code-block:: bash
 
-      $ sudo dnf install git pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
+      $ sudo dnf install git pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkit2gtk3
 
   .. group-tab:: Windows
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -94,7 +94,7 @@ Next, install the additional dependencies needed for your operating system:
 
     .. code-block:: bash
 
-      $ sudo dnf install git pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkit2gtk3
+      $ sudo dnf install git pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk4
 
   .. group-tab:: Windows
 


### PR DESCRIPTION
webkitgtk3 package has been retired from Fedora with release 27 (https://src.fedoraproject.org/rpms/webkitgtk3/c/6f85a399bfceed052fcb929e93c121d6cadfc7e3) and replaced with webkitgtk4 which was later renamed to webkit2gtk3.
webkit2gtk3 is packaged for all releases supported by the Fedora Project (https://src.fedoraproject.org/rpms/webkit2gtk3#bodhi_updates).
The browser tutorial from Toga documentation works with webkit2gtk3 installed.