### PR TITLE
Clarify instructions & fix typos - Tutorial 4

### DIFF
--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -81,9 +81,11 @@ for your existing bundled application:
 If Briefcase can't find the scaffolded template, it will automatically invoke
 `create` to generate a fresh scaffold.
 
-Now that we've updated the installer code, We can then run ``briefcase build``
+Now that we've updated the installer code, we can then run ``briefcase build``
 to re-compiled app, ``briefcase run`` to run the updated app, and ``briefcase
 package`` to repackage the application for distribution.
+
+(Remember that as noted in :doc:`Tutorial 3 <tutorial-3/index>`, for the tutorial we recommend running ``briefcase package`` with the ``--no-sign`` flag to avoid the complexity of setting up a code signing identity and keep the tutorial as simple as possible.)
 
 Updating dependencies and icons
 ===============================
@@ -186,5 +188,5 @@ We now have our application packaged for distribution on desktop platforms,
 and we've been able to update the code in our application.
 
 But what about mobile? In :doc:`Tutorial 5 <tutorial-5/index>`, we'll convert
-out application into a mobile application, and deploy it onto a device
+our application into a mobile application, and deploy it onto a device
 simulator, and onto a phone.

--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -85,7 +85,10 @@ Now that we've updated the installer code, we can then run ``briefcase build``
 to re-compiled app, ``briefcase run`` to run the updated app, and ``briefcase
 package`` to repackage the application for distribution.
 
-(macOS users, remember that as noted in :doc:`Tutorial 3 <tutorial-3/index>`, for the tutorial we recommend running ``briefcase package`` with the ``--no-sign`` flag to avoid the complexity of setting up a code signing identity and keep the tutorial as simple as possible.)
+(macOS users, remember that as noted in :doc:`Tutorial 3 <tutorial-3>`, for the
+tutorial we recommend running ``briefcase package`` with the ``--no-sign`` flag
+to avoid the complexity of setting up a code signing identity and keep the
+tutorial as simple as possible.)
 
 Updating dependencies and icons
 ===============================

--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -85,7 +85,7 @@ Now that we've updated the installer code, we can then run ``briefcase build``
 to re-compiled app, ``briefcase run`` to run the updated app, and ``briefcase
 package`` to repackage the application for distribution.
 
-(Remember that as noted in :doc:`Tutorial 3 <tutorial-3/index>`, for the tutorial we recommend running ``briefcase package`` with the ``--no-sign`` flag to avoid the complexity of setting up a code signing identity and keep the tutorial as simple as possible.)
+(macOS users, remember that as noted in :doc:`Tutorial 3 <tutorial-3/index>`, for the tutorial we recommend running ``briefcase package`` with the ``--no-sign`` flag to avoid the complexity of setting up a code signing identity and keep the tutorial as simple as possible.)
 
 Updating dependencies and icons
 ===============================


### PR DESCRIPTION
When I did the tutorial I tripped up when I ran the updated app for the first time because I forgot the earlier note to leave off ``--no-sign`` from ``briefcase package``. A reminder could help future users avoid this issue.