### PR TITLE
Clarify Tutorial 3 - running packaged app

### DIFF
--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -286,10 +286,12 @@ You can now use Briefcase to run your application:
 This will start to run your native application, using the output of the
 `build` command.
 
-You'll notice that the console output we saw earlier won't work anymore. This is because we are now running a standalone, packaged app that has no console to output to.
+You'll notice that the console output we saw earlier won't be visible anymore. 
+This is because we are now running a standalone, packaged app that has no 
+(visible) console to which it can output. 
 
-You might also notice some small differences in the way your application looks when
-it's running. For example, icons and the name displayed by the operating
+You might also notice some small differences in the way your application looks 
+when it's running. For example, icons and the name displayed by the operating
 system may be slightly different to those you saw when running under developer
 mode. This is also because you're using the packaged application, not just
 running Python code. From the operating system's perspective, you're now

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -283,17 +283,18 @@ You can now use Briefcase to run your application:
 
       (beeware-venv) C:\...>
 
-This will start your run your native application, using the output of the
+This will start to run your native application, using the output of the
 `build` command.
 
-You may notice some small differences in the way your application looks when
-it's running - for example, icons, and the name displayed by the operating
-system, may be slightly different to those you saw when running under developer
-mode. This is because you're using the actual packaged application, not just
+You'll notice that the console output we saw earlier won't work anymore. This is because we are now running a standalone, packaged app that has no console to output to.
+
+You might also notice some small differences in the way your application looks when
+it's running. For example, icons and the name displayed by the operating
+system may be slightly different to those you saw when running under developer
+mode. This is also because you're using the packaged application, not just
 running Python code. From the operating system's perspective, you're now
-running "an app", not "a Python program", and that is reflected in how the
-application appears. The console output we saw earlier also won't work anymore,
-since we are running a standalone app that has no console to output to.
+running "an app", not "a Python program", and this is reflected in how the
+application appears. 
 
 Building your installer
 =======================


### PR DESCRIPTION
When I went through the tutorial I missed the note describing why console output doesn't appear when running the packaged app in Tutorial 3. Bringing the console output point up earlier in the section could help make it more obvious and harder to miss for others.