### PR TITLE
Update android.rst: include how to view logs.

### DIFF
--- a/docs/tutorial/tutorial-5/android.rst
+++ b/docs/tutorial/tutorial-5/android.rst
@@ -349,6 +349,14 @@ In the future, if you want to run on this device without using the menu, you can
 provide the phones's serial number to Briefcase, using ``briefcase run android
 -d 94ZZY0LNE8``. Thi will run on the device directly, wthout prompting.
 
+.. note::
+
+    When you’re developing for Android, it's useful to be able to view the
+    Android logs. To view the Android logs without the background noise from
+    the rest of the system, you can run ``adb logcat -s MainActivity:* stdio:*
+    Python:*``. Anything your app writes to stdout (e.g., the output of
+    ``print()`` statements) will be visible in the logs.
+
 Next steps
 ==========
 


### PR DESCRIPTION
I've added a note to the Android page of the tutorial, giving instructions about how to view logs.

Fixes beeware/briefcase#505

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- n/a – All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
