### PR TITLE
Docker permission error

### DIFF
--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -85,7 +85,7 @@ From the ``helloworld`` directory, run:
 
         newgrp docker
 
-      Restart your computer and you should be good to go.
+      Once you restart your computer you'll be able to run: briefcase create
 
   .. group-tab:: Windows
 

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -74,8 +74,8 @@ From the ``helloworld`` directory, run:
 
     .. admonition:: Possible Docker error on Ubuntu
 
-      If you encounter a Docker permissions error, you may need to create a 
-      Docker group. To do so, follow these steps:
+      If you encounter a Docker permissions error, you may need to add your
+      user account to the Docker group. To do so, use these commands:
 
       .. code_block:: bash
 
@@ -85,7 +85,7 @@ From the ``helloworld`` directory, run:
 
         newgrp docker
 
-      Once you restart your computer you'll be able to run: briefcase create
+      Restart your computer you'll be able to run: briefcase create
 
   .. group-tab:: Windows
 

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -77,7 +77,7 @@ From the ``helloworld`` directory, run:
       If you encounter a Docker permissions error, you may need to add your
       user account to the Docker group. To do so, use these commands:
 
-      .. code_block:: bash
+      .. code-block:: bash
 
         sudo groupadd Docker
 

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -72,6 +72,11 @@ From the ``helloworld`` directory, run:
       binaries. This involves downloading a lot of system packages. On future
       runs, this Docker image will be re-used.
 
+    .. admonition:: Possible Docker error on Ubuntu
+
+      If you encounter a Docker permissions error, you may need to create a 
+      Docker group.
+
   .. group-tab:: Windows
 
     .. code-block:: doscon

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -75,7 +75,17 @@ From the ``helloworld`` directory, run:
     .. admonition:: Possible Docker error on Ubuntu
 
       If you encounter a Docker permissions error, you may need to create a 
-      Docker group.
+      Docker group. To do so, follow these steps:
+
+      .. code_block:: bash
+
+        sudo groupadd Docker
+
+        sudo usermod -aG docker $USER
+
+        newgrp docker
+
+      Restart your computer and you should be good to go.
 
   .. group-tab:: Windows
 


### PR DESCRIPTION
I added an admonition to the Linux tab in the Tutorial 3 docs
I was taking the tutorial, running POP!_OS version 20.10 and it lays out the steps I took to fix a docker permissions error when I tried to run `briefcase create`. 



## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
