### PR TITLE
Fix "next steps" to point to the correct next tutorial

### DIFF
--- a/docs/tutorial/tutorial-9.rst
+++ b/docs/tutorial/tutorial-9.rst
@@ -10,6 +10,6 @@ the web! Using the same API, you can deploy your application as a web site.
 Next steps
 ==========
 
-We've now got an application on our phone! Is there anywhere other way to
-deploy a BeeWare app? Turn to :doc:`Tutorial 9 <tutorial-9>` to find
+We've now got the application on the web! How about builting an installer
+for your application? Turn to :doc:`Tutorial 10 <tutorial-10>` to find
 out...

--- a/docs/tutorial/tutorial-9.rst
+++ b/docs/tutorial/tutorial-9.rst
@@ -10,6 +10,5 @@ the web! Using the same API, you can deploy your application as a web site.
 Next steps
 ==========
 
-We've now got the application on the web! How about builting an installer
-for your application? Turn to :doc:`Tutorial 10 <tutorial-10>` to find
-out...
+We've now got the application on the web! How about publishing your app?
+Turn to :doc:`Tutorial 10 <tutorial-10>` to find out...


### PR DESCRIPTION
The _next steps_ for stub tutorial 9 was pointing back to itself.
Now it should reference the next tutorial.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
