### PR TITLE
Update tutorial-3.rst

### DIFF
--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -89,7 +89,7 @@ From the ``helloworld`` directory, run:
       ...
       [helloworld] Installing application resources...
       ...
-      [helloworld] Created windows\Hello World
+      [helloworld] Created windows\msi\Hello World
 
 You've probably just seen pages of content go past in your terminal... so what
 just happened? Briefcase has done the following:
@@ -311,7 +311,7 @@ or doing other pre-distribution tasks.
 
       [helloworld] Building MSI...
       ...
-      [helloworld] Created windows\Hello_World-0.0.1.msi
+      [helloworld] Packaged windows\Hello_World-0.0.1.msi
 
     Once this step completes, the ``windows`` folder will contain a file named
     ``Hello_World-0.0.1.msi``. If you double click on this installer to run it,


### PR DESCRIPTION
On Windows 11 Version 10.0.22000 Build 22000
command 'briefcase create' will create windows\msi\Hello World instead of just windows\Hello World

command 'briefcase package' will output 'Packaged' instead of 'Created'

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
