### PR TITLE
Explain logging console output for `briefcase run`.

### DIFF
--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -251,11 +251,14 @@ running Python code. From the operating system's perspective, you're now
 running "an app", not "a Python program", and this is reflected in how the
 application appears.
 
-You'll also notice some small differences with the console output we saw earlier
-as it is now extracted from the system or device logs. The logging process will
-not be terminated when we close the application. Please type CTRL-C to stop the
-logging process.
-
+If you're on macOS, you'll also notice some small differences in the console
+output we saw earlier. This is because the packaged app writes its console
+output to the system log. When you run the packaged app, you're seeing a
+filtered version of the system log, not raw console output; and as a result,
+there's more system log details (like timestamps and the message source) being 
+displayed. When you close the application, the system log will continue to run, 
+even though there are no more logs to display. You can stop the display of the
+system log by typing Ctrl-C.
 
 Building your installer
 =======================

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -243,13 +243,19 @@ You'll notice that the console output we saw earlier won't be visible anymore.
 This is because we are now running a standalone, packaged app that has no 
 (visible) console to which it can output. 
 
-You might also notice some small differences in the way your application looks 
+You might notice some small differences in the way your application looks
 when it's running. For example, icons and the name displayed by the operating
 system may be slightly different to those you saw when running under developer
 mode. This is also because you're using the packaged application, not just
 running Python code. From the operating system's perspective, you're now
 running "an app", not "a Python program", and this is reflected in how the
-application appears. 
+application appears.
+
+You'll also notice some small differences with the console output we saw earlier
+as it is now extracted from the system or device logs. The logging process will
+not be terminated when we close the application. Please type CTRL-C to stop the
+logging process.
+
 
 Building your installer
 =======================


### PR DESCRIPTION
Just a minor documentation update as I explore beeware :)

As the logging console output is enabled for `briefcase run` in #591, the description in Tutorial 3 should be updated to reflect the capability.

<img width="810" alt="Screen Shot 2022-05-25 at 17 01 14" src="https://user-images.githubusercontent.com/1992348/170229498-1b8bfcd6-a567-4714-b996-80b879fb37f2.png">

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
