### PR TITLE
docs: Include OS in beeware run command

### DIFF
--- a/docs/tutorial/tutorial-5/iOS.rst
+++ b/docs/tutorial/tutorial-5/iOS.rst
@@ -84,7 +84,7 @@ If you have multiple iPhone 11 simulators, briefcase will pick the highest
 iOS version; if you want to pick a particular iOS version, you tell it to use
 that specific version::
 
-    $ briefcase run iOS -d "iPhone 11::13.3"
+    $ briefcase run iOS -d "iPhone 11::iOS 13.3"
 
 Or, you can name a specific device UDID::
 


### PR DESCRIPTION
To run a specific version of iOS simulator, we need to pass traget device as `-d "iPhone 13::iOS 15.4"`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
