### PR TITLE
Increase minimum Python version to 3.8

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -8,8 +8,7 @@ all the prerequisites for running BeeWare.
 Install Python
 ==============
 
-The first thing we'll need is a working Python interpreter, running Python 3.7
-or newer.
+The first thing we'll need is a working Python interpreter.
 
 .. tabs::
 
@@ -17,7 +16,7 @@ or newer.
 
     If you're on macOS, you can get the official installer from `the Python
     website <https://www.python.org/downloads>`_. You can use any stable version
-    of Python from 3.7 onward. We'd advise avoiding alphas, betas, and release
+    of Python from 3.8 onward. We'd advise avoiding alphas, betas, and release
     candidates unless you *really* know what you're doing.
 
   .. group-tab:: Linux
@@ -25,7 +24,7 @@ or newer.
     If you're on Linux, you'll install Python using the system package manager
     (``apt`` on Debian/Ubuntu/Mint; ``dnf`` on Fedora, or ``pacman`` on Arch).
 
-    You should ensure that the system Python is Python 3.7 or newer; if it isn't
+    You should ensure that the system Python is Python 3.8 or newer; if it isn't
     (e.g., Ubuntu 18.04 ships with Python 3.6), you may need to use an alternate
     source for Python (e.g., the `deadsnakes PPA
     <https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa>`__ on Ubuntu).
@@ -36,7 +35,7 @@ or newer.
 
     If you're on Windows, you can get the official installer from `the Python
     website <https://www.python.org/downloads>`_. You can use any stable version
-    of Python from 3.7 onward. We'd advise avoiding alphas, betas and release
+    of Python from 3.8 onward. We'd advise avoiding alphas, betas and release
     candidates unless you *really* know what you're doing.
 
 .. admonition:: Alternative Python distributions


### PR DESCRIPTION
This has been the minimum since Briefcase 0.3.10 (https://github.com/beeware/briefcase/pull/862).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
