### PR TITLE
fix typo in `tutorial-8.rst`

### DIFF
--- a/docs/tutorial/tutorial-8.rst
+++ b/docs/tutorial/tutorial-8.rst
@@ -68,7 +68,7 @@ we can have a long-running event handler *and* maintain a responsive UI.
 
 We can do this by using *asynchronous programming*. Asynchronous programming is
 a way to describe a program that allows the interpreter to run multiple
-functions a the same time, sharing resources between all the concurrently running
+functions at the same time, sharing resources between all the concurrently running
 functions.
 
 Asynchronous functions (known as *co-routines*) need to be explicitly declared


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes a very small typo for `a same time` -> `at the same time`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
