### PR TITLE
Update docs to reflect the change in command line argument

### DIFF
--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -263,7 +263,7 @@ the application again. As before, we'll use developer mode:
 You'll notice that this time, it *doesn't* install dependencies. Briefcase can
 detect that the application has been run before, and to save time, will only
 run the application. If you add new dependencies to your app, you can make
-sure that they're installed by passing in a ``-d`` option when you run
+sure that they're installed by passing in a ``-r`` option when you run
 ``briefcase dev``.
 
 This should open a GUI window:


### PR DESCRIPTION
The briefcase CLI arguments were updated ([2391eb3576cc20798dafc0e1d1fc6acc9522cabf](https://github.com/beeware/briefcase/commit/2391eb3576cc20798dafc0e1d1fc6acc9522cabf#diff-382be9590ee70b12ff44576dff6a0a9334e332e0a39522504572eebf07b73940L30)) but this line in the docs seems to have been missed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
