### PR TITLE
Typo in tutorial-4.rst

### DIFF
--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -117,7 +117,7 @@ to re-compile the app, ``briefcase run`` to run the updated app, and ``briefcase
 package`` to repackage the application for distribution.
 
 (macOS users, remember that as noted in :doc:`Tutorial 3 <tutorial-3>`, for the
-tutorial we recommend running ``briefcase package`` with the ``--no-sign`` flag
+tutorial we recommend running ``briefcase package`` with the ``--adhoc-sign`` flag
 to avoid the complexity of setting up a code signing identity and keep the
 tutorial as simple as possible.)
 


### PR DESCRIPTION
Tutorial 3 says to use the `--adhoc-sign` flag, not `--no-sign`.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
