### PR TITLE
Clarify Linux system requirements for tutorial

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -94,20 +94,20 @@ Next, install the additional dependencies needed for your operating system:
 
     .. code-block:: console
 
-      $ sudo apt-get update
-      $ sudo apt-get install build-essential git python3-dev python3-venv python3-cairo-dev python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev gir1.2-webkit2-4.0 pkg-config
+      $ sudo apt update
+      $ sudo apt install build-essential git pkg-config python3-dev python3-venv libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0
 
     **Fedora**
 
     .. code-block:: console
 
-      $ sudo dnf install git pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk4
+      $ sudo dnf install git pkg-config rpm-build python3-devel gobject-introspection-devel cairo-gobject-devel webkitgtk4
 
     **Arch, Manjaro**
 
     .. code-block:: console
 
-      $ sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk
+      $ sudo pacman -Syu base-devel git pkgconf python3 gobject-introspection cairo libcanberra gtk3 webkit2gtk
 
   .. group-tab:: Windows
 


### PR DESCRIPTION
## Changes
- I've been meaning to address this for a while but I noticed the Linux system pre-reqs are a little too broad.
- System cairo Python packages
  - The `python3-cairo-dev` and `python3-gi-cairo` packages aren't needed since we aren't expecting the system to provide the Python interfaces.
  - The `PyGObject` PyPI package brings everything it needs to use cairo. And this aligns with pip install [instructions](https://pygobject.readthedocs.io/en/latest/getting_started.html).
- Pango
  - I can't think of what needs pango headers via `libpango1.0-dev`???
  - That said, `libpango` will be installed via `libgtk-3-0` via `gir1.2-webkit2-4.0`
- RHEL and Archlinux
  - Added the packages necessary to actually build an arch package or rpm
- Testing
  - I tested all this using minimal docker images to avoid random packages already existing in the environment

Once we have consensus here, I'll align CI and other docs with this.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
