### PR TITLE
Replace superseded `webkitgtk4` with `webkit2gtk3`

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -101,7 +101,7 @@ Next, install the additional dependencies needed for your operating system:
 
     .. code-block:: console
 
-      $ sudo dnf install git pkg-config rpm-build python3-devel gobject-introspection-devel cairo-gobject-devel webkitgtk4 libcanberra-gtk3
+      $ sudo dnf install git pkg-config rpm-build python3-devel gobject-introspection-devel cairo-gobject-devel webkit2gtk3 libcanberra-gtk3
 
     **Arch, Manjaro**
 


### PR DESCRIPTION
- https://github.com/beeware/beeware/pull/50 used `webkitgtk4` since it was more widely available after the rename to `webkit2gtk3`. I think these concerns should be mitigated now given most of the unsupported distro versions are EOL.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
