### PR TITLE
Differentiate the concurrency groups for CI and translation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 # Cancel active CI runs for a PR before starting another run
 concurrency:
-  group: ${{ github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -6,7 +6,7 @@ on:
 
 # Cancel active CI runs for a PR before starting another run
 concurrency:
-  group: ${{ github.ref }}
+  group: translate-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
CI on main and translations on main were using the same concurrency group. Differentiate the two groups so that *both* workflows will run.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
