### PR TITLE
Update tutorial-0.rst:add max python version.

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -30,7 +30,7 @@ The first thing we'll need is a working Python interpreter.
     If you're on Linux, you'll install Python using the system package manager
     (``apt`` on Debian/Ubuntu/Mint, ``dnf`` on Fedora, or ``pacman`` on Arch).
 
-    You should ensure that the system Python is Python 3.8 or newer; if it isn't
+    You should ensure that the system Python is between 3.8 and 3.11; if it isn't
     (e.g., Ubuntu 18.04 ships with Python 3.6), you'll need to upgrade your
     Linux distribution to something more recent.
 
@@ -40,7 +40,7 @@ The first thing we'll need is a working Python interpreter.
 
     If you're on Windows, you can get the official installer from `the Python
     website <https://www.python.org/downloads>`_. You can use any stable version
-    of Python from 3.8 onward. We'd advise avoiding alphas, betas, and release
+    of Python between 3.8 up to 3.11. We'd advise avoiding alphas, betas, and release
     candidates unless you *really* know what you're doing.
 
 .. admonition:: Alternative Python distributions

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -23,7 +23,8 @@ The first thing we'll need is a working Python interpreter.
       $ python3 --version
 
     If Python is installed, you'll see its version number. Otherwise, you'll
-    be prompted to install the command line developer tools.
+    be prompted to install the command line developer tools. Make sure that the
+    Python Version is between 3.8 and 3.11.
 
   .. group-tab:: Linux
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Add the max supported version for Python to the Version-checking section of Tutorial 0.

The max version is currently 3.11.

<!--- What problem does this change solve? -->

If someone had installed a Python version that is newer than the currently supported Python versions, before the tutorial they would expect 3.12 to work. Because of that, they will run into an error when trying to build for Android. Since now the tutorial makes sure that anyone who works through the tutorial will always have a compatible version of Python or a hint to install pyenv and use that to set the version to a supported one. This error should not occur again.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

I had the conversation about this in the Briefcase issues as I thought it was a problem with Briefcase and not with the documentation.

[#1602](https://github.com/beeware/briefcase/issues/1602)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested

No, and I would not know how as there is currently no tutorial on how I would do so. As only text is changed, I would expect that this might not be needed. GitHub Actions could be interesting here.

- [X] All new features have been documented

- [X] I have read the **CONTRIBUTING.md** file

Very interesting read. Would suggest putting a link to this right at the beginning of Tutorial 0 so that people already know how to contribute to the tutorial they are currently going through.

- [X] I will abide by the code of conduct

Signed-off-by: Christoph Backhaus <christoph.backhaus@nadooit.de>
