### PR TITLE
Correct the output path for the translation update step.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
     lint : python -m sphinx {[docs]sphinx_args} {posargs} -b spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
     live : sphinx-autobuild {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}live
     translate : python -m sphinx {[docs]sphinx_args} {posargs} -b gettext {[docs]docs_dir} {[docs]build_dir}{/}gettext
-    translate : python -m sphinx_intl update -p {[docs]build_dir}{/}gettext -d {[docs]docs_dir}/locales -w 0 -l de,es,fr,it,pt,zh_CN
+    translate : python -m sphinx_intl update -p {[docs]build_dir}{/}gettext -d {[docs]docs_dir}{/}locales -w 0 -l de,es,fr,it,pt,zh_CN
     all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html {[docs]docs_dir} {[docs]build_dir}{/}html{/}en
     # Replace `-t machine_translation` with `-t human_translation` if/when a translation
     # has been audited by a human. The ReadTheDocs environment variable should also be

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
     lint : python -m sphinx {[docs]sphinx_args} {posargs} -b spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
     live : sphinx-autobuild {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}live
     translate : python -m sphinx {[docs]sphinx_args} {posargs} -b gettext {[docs]docs_dir} {[docs]build_dir}{/}gettext
-    translate : python -m sphinx_intl update -p {[docs]build_dir}{/}gettext -w 0 -l de,es,fr,it,pt,zh_CN
+    translate : python -m sphinx_intl update -p {[docs]build_dir}{/}gettext -d {[docs]docs_dir}/locales -w 0 -l de,es,fr,it,pt,zh_CN
     all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html {[docs]docs_dir} {[docs]build_dir}{/}html{/}en
     # Replace `-t machine_translation` with `-t human_translation` if/when a translation
     # has been audited by a human. The ReadTheDocs environment variable should also be


### PR DESCRIPTION
#310 reworked the Sphinx targets; however, I missed that the locale output directory was no longer correct as part of the changes (it was outputting into the project root directory, rather than the docs directory, due to the removal of the `change_dir` instruction). 

This manifested as a [build failure on the Update Translations job when the PR was merged](https://github.com/beeware/beeware/actions/runs/8196377252/job/22416468219).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
