### PR TITLE
Bump black-pre-commit-mirror from 24.2.0 to 24.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.2.0
+    rev: 24.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.2.0 to 24.3.0 and ran the update against the repo.