### PR TITLE
Bump pyupgrade from v3.15.1 to v3.15.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         exclude: "docs/locales"
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args: [--py38-plus]


### PR DESCRIPTION
Bumps `pre-commit` hook for `pyupgrade` from v3.15.1 to v3.15.2 and ran the update against the repo.