### PR TITLE
Added admoniton for a possible error fix

### DIFF
--- a/docs/tutorial/tutorial-5/android.rst
+++ b/docs/tutorial/tutorial-5/android.rst
@@ -105,6 +105,23 @@ considerable; this may take a while (10 minutes or longer, depending on the
 speed of your Internet connection). When the download has completed, you will
 be prompted to accept Google's Android SDK license.
 
+.. admonition:: I end up with a "PermissionError: [WinError 5] Access denied:" error!
+
+    In case your system needs it, the "briefcase create android" command will try to
+    "Installing Android SDK Command-Line Tools" and you may encounter this error.
+    It may be the case that the system didn't create the folder of the specific version
+    you're trying to install and at the same time it's trying to address it.
+    Check at the path:
+    "AppData\Local\BeeWare\briefcase\Cache\tools\android_sdk\cmdline-tools\cmdline-tools".
+    In case the folder with the version number your system is looking for is missing, create it manually.
+
+    As an example:
+    if the error reads
+    "PermissionError: [WinError 5] Access denied: 'C:\\...\\AppData\\Local\\BeeWare\\briefcase\\Cache\\tools\\android_sdk\\cmdline-tools\\cmdline-tools' ->  
+    'C:\\...\\AppData\\Local\\BeeWare\\briefcase\\Cache\\tools\\android_sdk\\cmdline-tools\\9.0'"
+    and you can't find the "9.0" folder at that path, just create it and then launch again the
+    ``briefcase create android`` command.
+
 Once this completes, we'll have a
 ``build\helloworld\android\gradle`` directory in our project, which will contain
 an Android project with a Gradle build configuration. This project will contain


### PR DESCRIPTION
While following the tutorial I got a Permission Error and didn't know how to proceed.

I've tried adding a folder the system was looking for and then the process continued smoothly. I thought that adding this admonition to the tutorial may help others in case this happens to them as well.

<!--- Describe your changes in detail -->
I added an admonition to let people know a possible solution to a possible problem encountered after the "briefcase build android" command.

<!--- What problem does this change solve? -->
Personally at first I found myself lost and I was even looking for other python-to-android builders and came back just because I've not found any that convinced me.
Adding that hint may help others not lose their time by doing that.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested: the briefcase build android command worked and actually filled the folder. Now I have another problem with "briefcase runandroid", but I don't think it's correlated (the folder I manually created has been correctly filled by the "briefcase build android" command)
- [x ] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
