### PR TITLE
Add missing "not" to tutorial-7.rst for clarity

### DIFF
--- a/docs/tutorial/tutorial-7.rst
+++ b/docs/tutorial/tutorial-7.rst
@@ -316,8 +316,8 @@ we've made code changes, we need to follow the same steps as in :doc:`Tutorial 4
        :align: center
        :alt: Hello World Tutorial 7 app crash, on Windows
 
-Once again, the app has failed to start because ``httpx`` has been installed - but
-why? Haven't we already installed ``httpx``?
+Once again, the app has failed to start because ``httpx`` has not been installed -
+but why? Haven't we already installed ``httpx``?
 
 We have - but only in the development environment. Your development environment
 is entirely local to your machine - and is only enabled when you explicitly


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Pretty sure it's supposed to say "Once again, the app has failed to start because httpx not has been installed - but why? Haven’t we already installed httpx?" instead of what it currently says.
<!--- What problem does this change solve? -->
Mistaken language saying the opposite of what it means
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
