### PR TITLE
Add `check-wheel-contents` config to ignore empty wheel errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,8 @@ combine_as_imports = true
 
 [tool.setuptools_scm]
 # To enable SCM versioning, we need an empty tool configuration for setuptools_scm
+
+[tool.check-wheel-contents]
+# WOO7: wheel library is empty
+# W008: wheel is empty
+ignore = "W007,W008"

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,9 @@ commands =
 skip_install = True
 deps =
     build==1.2.1
+    check-wheel-contents==0.6.0
     twine==5.1.0
 commands =
     python -m build . --outdir dist{/}
     python -m twine check dist{/}*
+    check-wheel-contents dist{/}


### PR DESCRIPTION
## Changes
- Add `check-wheel-contents` config for https://github.com/beeware/.github/pull/137

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct