### PR TITLE
Add explicit RTD version pin, and protect against sphinx 8 deprecations.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    # Docs are always built on Python 3.12. See also the tox config.
     python: "3.12"
   jobs:
     pre_build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
   jobs:
     pre_build:
       - tox -e docs-lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,15 @@ docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
     # Sphinx 7.2 deprecated support for Python 3.8
+    # Sphinx 8.0 deprecated support for Python 3.9
     "sphinx == 7.1.2 ; python_version < '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.9'",
-    "sphinx_design == 0.6.0",
+    "sphinx == 7.4.7 ; python_version == '3.9'",
+    "sphinx == 7.4.7 ; python_version >= '3.10'",
+    # sphinx-design 0.6 deprecated support for Python 3.8
+    "sphinx_design == 0.5.0 ; python_version < '3.9'",
+    "sphinx_design == 0.6.1 ; python_version >= '3.9'",
     "sphinx_tabs == 3.4.5",
-    # Sphinx 2024.2.4 deprecated support for Python 3.8
+    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
     "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
     "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
     "sphinx-copybutton == 0.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "setuptools_scm == 8.1.0",
     "tox == 4.16.0",
 ]
-# Docs are always built on Py3.12; see RTD and tox config files.
+# Docs are always built on a specific Python version; see RTD and tox config files.
 docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,21 +51,14 @@ dev = [
     "setuptools_scm == 8.1.0",
     "tox == 4.16.0",
 ]
+# Docs are always built on Py3.12; see RTD and tox config files.
 docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
-    # Sphinx 7.2 deprecated support for Python 3.8
-    # Sphinx 8.0 deprecated support for Python 3.9
-    "sphinx == 7.1.2 ; python_version < '3.9'",
-    "sphinx == 7.4.7 ; python_version == '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.10'",
-    # sphinx-design 0.6 deprecated support for Python 3.8
-    "sphinx_design == 0.5.0 ; python_version < '3.9'",
-    "sphinx_design == 0.6.1 ; python_version >= '3.9'",
+    "sphinx == 7.4.7",
+    "sphinx_design == 0.6.1",
     "sphinx_tabs == 3.4.5",
-    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
-    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
-    "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
+    "sphinx-autobuild == 2024.4.16",
     "sphinx-copybutton == 0.5.2",
     "sphinx-intl == 2.2.0",
     "sphinxcontrib-spelling == 8.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -33,16 +33,10 @@ commands = python -m pytest {posargs:-vv --color yes}
 [docs]
 docs_dir = {tox_root}{/}docs
 build_dir = {[docs]docs_dir}{/}_build
-# replace when Sphinx>=7.3 and Python 3.8 is dropped:
-#  -T => --show-traceback
-#  -W => --fail-on-warning
-#  -b => --builder
-#  -v => --verbose
-#  -a => --write-all
-#  -E => --fresh-env
-sphinx_args = -T -W --keep-going --jobs auto
+sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-translate,-all,-live}]
+base_python = python3.12
 package = wheel
 wheel_build_env = .pkg
 extras = docs
@@ -52,20 +46,20 @@ passenv =
     #     export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
     PYENCHANT_LIBRARY_PATH
 commands =
-    !lint-!all-!translate-!live : python -m sphinx {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}html{/}en
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} -b linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} -b spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
-    live : sphinx-autobuild {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}live
-    translate : python -m sphinx {[docs]sphinx_args} {posargs} -b gettext {[docs]docs_dir} {[docs]build_dir}{/}gettext
+    !lint-!all-!translate-!live : python -m sphinx {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}html{/}en
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
+    live : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}live
+    translate : python -m sphinx {[docs]sphinx_args} {posargs} --builder gettext {[docs]docs_dir} {[docs]build_dir}{/}gettext
     translate : python -m sphinx_intl update -p {[docs]build_dir}{/}gettext -d {[docs]docs_dir}{/}locales -w 0 -l de,es,fr,it,pt,zh_CN,zh_TW
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html {[docs]docs_dir} {[docs]build_dir}{/}html{/}en
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html {[docs]docs_dir} {[docs]build_dir}{/}html{/}en
     # Replace `-t machine_translation` with `-t human_translation` if/when a translation
     # has been audited by a human. The ReadTheDocs environment variable should also be
     # updated to read `TRANSLATION=human`.
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=de -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}de
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=es -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}es
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=fr -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}fr
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=it -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}it
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=pt -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}pt
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=zh_CN -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}zh-cn
-    all : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html -D language=zh_TW -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}zh-tw
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=de -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}de
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=es -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}es
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=fr -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}fr
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=it -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}it
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=pt -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}pt
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=zh_CN -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}zh-cn
+    all : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html -D language=zh_TW -t machine_translation {[docs]docs_dir} {[docs]build_dir}{/}html{/}zh-tw

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ build_dir = {[docs]docs_dir}{/}_build
 sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-translate,-all,-live}]
+# Docs are always built on Python 3.12. See also the RTD config.
 base_python = py312
 package = wheel
 wheel_build_env = .pkg

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ build_dir = {[docs]docs_dir}{/}_build
 sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-translate,-all,-live}]
-base_python = python3.12
+base_python = py312
 package = wheel
 wheel_build_env = .pkg
 extras = docs


### PR DESCRIPTION
To ensure a consistent and repeatable build environment, use a hard version pin on the RTD environment.

Also adds a pin to Sphinx on Python 3.9, as Sphinx 8 deprecates Python 3.9 support; and a pin to sphinx-design on Python 3.8.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
