### PR TITLE
Add warning about Python 3.13 on Windows.

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -47,8 +47,9 @@ The first thing we'll need is a working Python interpreter.
 
     If you're on Windows, you can get the official installer from `the Python
     website <https://www.python.org/downloads>`_. You can use any stable version
-    of Python from 3.9 onward. We'd advise avoiding alphas, betas, and release
-    candidates unless you *really* know what you're doing.
+    of Python from 3.9 to 3.12 - Python 3.13 is *not* currently supported. We'd
+    also advise avoiding alphas, betas, and release candidates unless you
+    *really* know what you're doing.
 
 .. admonition:: Alternative Python distributions
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -47,9 +47,10 @@ The first thing we'll need is a working Python interpreter.
 
     If you're on Windows, you can get the official installer from `the Python
     website <https://www.python.org/downloads>`_. You can use any stable version
-    of Python from 3.9 to 3.12 - Python 3.13 is *not* currently supported. We'd
-    also advise avoiding alphas, betas, and release candidates unless you
-    *really* know what you're doing.
+    of Python from 3.9 to 3.12 - `Python 3.13 is not currently supported
+    <https://github.com/beeware/toga/issues/2889>`__. We'd also advise avoiding
+    alphas, betas, and release candidates unless you *really* know what you're
+    doing.
 
 .. admonition:: Alternative Python distributions
 


### PR DESCRIPTION
Python 3.13.0 is imminent, but Python.net explicitly excludes 3.13 support because of a known crash (see pythonnet/pythonnet#2454). 

When 3.13.0 is released, it will become the default download on python.org, so we need to get ahead of those users.

This doesn't affect Linux users, as the system Python won't be Python 3.13 anywhere for at least a couple of months (and even when it is, the PyGobject dependency can be compiled for 3.13); on macOS, Rubicon has been tested with 3.13.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
