### PR TITLE
Use toga.InfoDialog() instead of info_dialog()

### DIFF
--- a/docs/tutorial/topics/camera-access.rst
+++ b/docs/tutorial/topics/camera-access.rst
@@ -89,14 +89,18 @@ that it has the following content:
                 if image:
                     self.photo.image = image
             except NotImplementedError:
-                await self.main_window.info_dialog(
-                    "Oh no!",
-                    "The Camera API is not implemented on this platform",
+                await self.main_window.dialog(
+                    toga.InfoDialog(
+                        "Oh no!",
+                        "The Camera API is not implemented on this platform",
+                    )
                 )
             except PermissionError:
-                await self.main_window.info_dialog(
-                    "Oh no!",
-                    "You have not granted permission to take photos",
+                await self.main_window.dialog(
+                    toga.InfoDialog(
+                        "Oh no!",
+                        "You have not granted permission to take photos",
+                    )
                 )
 
 

--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -29,7 +29,7 @@ Modify the ``say_hello`` callback so it looks like this::
         )
 
 We need to make the method ``async`` so that when we display the dialog, the rest of
-the application continues to run. Don't worry about this detail too much right now - 
+the application continues to run. Don't worry about this detail too much right now -
 we'll give a more detailed explanation in :doc:`Tutorial 8 <tutorial-8>`.
 
 This directs Toga to open a modal dialog box when the button is pressed.

--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -28,8 +28,9 @@ Modify the ``say_hello`` callback so it looks like this::
             )
         )
 
-Ignore the `async` and `await` for now. We will talk about this in detail
-later on in :doc:`Tutorial 8 <tutorial-8>`.
+We need to make the method ``async`` so that when we display the dialog, the rest of
+the application continues to run. Don't worry about this detail too much right now - 
+we'll give a more detailed explanation in :doc:`Tutorial 8 <tutorial-8>`.
 
 This directs Toga to open a modal dialog box when the button is pressed.
 

--- a/docs/tutorial/tutorial-4.rst
+++ b/docs/tutorial/tutorial-4.rst
@@ -20,11 +20,16 @@ need to use dialogs to communicate with users.
 Let's add a dialog box to say hello, instead of writing to the console.
 Modify the ``say_hello`` callback so it looks like this::
 
-    def say_hello(self, widget):
-        self.main_window.info_dialog(
-            f"Hello, {self.name_input.value}",
-            "Hi there!",
+    async def say_hello(self, widget):
+        await self.main_window.dialog(
+            toga.InfoDialog(
+                f"Hello, {self.name_input.value}",
+                "Hi there!",
+            )
         )
+
+Ignore the `async` and `await` for now. We will talk about this in detail
+later on in :doc:`Tutorial 8 <tutorial-8>`.
 
 This directs Toga to open a modal dialog box when the button is pressed.
 

--- a/docs/tutorial/tutorial-7.rst
+++ b/docs/tutorial/tutorial-7.rst
@@ -42,7 +42,7 @@ Let's add a ``httpx`` API call to our app. Add an import to the top of the
 
 Then modify the ``say_hello()`` callback so it looks like this::
 
-    def say_hello(self, widget):
+    async def say_hello(self, widget):
         with httpx.Client() as client:
             response = client.get("https://jsonplaceholder.typicode.com/posts/42")
 

--- a/docs/tutorial/tutorial-7.rst
+++ b/docs/tutorial/tutorial-7.rst
@@ -48,9 +48,11 @@ Then modify the ``say_hello()`` callback so it looks like this::
 
         payload = response.json()
 
-        self.main_window.info_dialog(
-            greeting(self.name_input.value),
-            payload["body"],
+        await self.main_window.dialog(
+            toga.InfoDialog(
+                greeting(self.name_input.value),
+                payload["body"],
+            )
         )
 
 This will change the ``say_hello()`` callback so that when it is invoked, it

--- a/docs/tutorial/tutorial-8.rst
+++ b/docs/tutorial/tutorial-8.rst
@@ -96,9 +96,11 @@ it looks like this::
 
         payload = response.json()
 
-        self.main_window.info_dialog(
-            greeting(self.name_input.value),
-            payload["body"],
+        await self.main_window.dialog(
+            toga.InfoDialog(
+                greeting(self.name_input.value),
+                payload["body"],
+            )
         )
 
 There are only 4 changes in this code from the previous version:


### PR DESCRIPTION
With toga [0.4.6](https://github.com/beeware/toga/releases/tag/v0.4.6), `info_dialog()` has been deprecated.
This addresses `async` part of the main tutorial.
Fixes #447

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
