### PR TITLE
Tutorial 1 file - Instructions on how to address a 'requirements not met' or 'pip unable to connect' error

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -5,6 +5,8 @@ Tutorial 0 - Let's get set up!
 Before we build our first BeeWare app, we have to make sure we've got
 all the prerequisites for running BeeWare.
 
+.. _install-python:
+
 Install Python
 ==============
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -176,8 +176,11 @@ and without the need to re-install Python.
 
        C:\...>md beeware-tutorial
        C:\...>cd beeware-tutorial
-       C:\...>py -m venv beeware-venv
+       C:\...>py -3.12 -m venv beeware-venv
        C:\...>beeware-venv\Scripts\activate
+
+    If you're not using Python 3.12, replace the ``-3.12`` in these instructions with
+    the version number that you are using.
 
     .. admonition:: Errors running PowerShell Scripts
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -228,8 +228,6 @@ This should open a GUI window:
         Unable to install requirements. This may be because one of your
         requirements is invalid, or because pip was unable to connect
         to the PyPI server.
-
-
       Confirm that you are running a :ref:`version of python that this tutorial supports
       <install-python>`.
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -221,7 +221,7 @@ This should open a GUI window:
 
     .. admonition:: Invalid requirements or pip unable to connect
 
-      You may encounter an error that reads:
+      If you encounter the error:
 
       .. code-block:: doscon
 
@@ -230,21 +230,11 @@ This should open a GUI window:
         to the PyPI server.
 
 
-      This is likely due to the use of an incompatible version of python (i.e. 3.13). To rectify this:
+      Confirm that you are running a `version of python that this tutorial supports
+      <install-python>`_.
 
-      Go to file manager and delete the venv and ``helloworld`` folder as that likely won’t work with the environment’s python version.
-      To fix the version discrepancy, either:
-
-      * Delete the incompatible python version (not advised)
-
-      * Specify the version of python to run the virtual environment in. Example:
-
-      .. code-block:: doscon
-
-        py -3.12 -m venv beeware-venv #specifies to use python 3.12.
-
-      * Repeat the earlier steps.
-
+      If your version of python is *not* a supported version, you will have to restart
+      the tutorial.
 
 Press the close button (or select Quit from the application's menu), and you're
 done! Congratulations - you've just written a standalone, native application

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -219,24 +219,33 @@ This should open a GUI window:
        :align: center
        :alt: Hello World Tutorial 1 window, on Windows
 
-  .. admonition:: Invalid requirements or pip unable to connect
+    .. admonition:: Invalid requirements or pip unable to connect
 
 
-    You may encounter an error that reads:
+      You may encounter an error that reads:
 
 
-    ``Unable to install requirements. This may be because one of your
-    requirements is invalid, or because pip was unable to connect
-    to the PyPI server.``
+      .. code-block:: doscon
+
+        Unable to install requirements. This may be because one of your
+        requirements is invalid, or because pip was unable to connect
+        to the PyPI server.
 
 
-    This is likely due to the use of an incompatible version of python (ie 3.13). To rectify this:
+      This is likely due to the use of an incompatible version of python (ie 3.13). To rectify this:
+
       Go to file manager and delete the venv and helloworld folder as that likely won’t work with the environment’s python version.
       To fix the version discrepancy, either:
-        Delete the incompatible python version (not advised)
-        Specify the version of python to run the virtual environment in. Example:
-          “py -3.12 -m venv beeware-venv” specifies to use python 3.12.
-      Repeat the earlier steps.
+
+      * Delete the incompatible python version (not advised)
+      
+      * Specify the version of python to run the virtual environment in. Example:
+        
+      .. code-block:: doscon
+
+        py -3.12 -m venv beeware-venv #specifies to use python 3.12.
+
+      * Repeat the earlier steps.
 
 
 Press the close button (or select Quit from the application's menu), and you're

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -230,8 +230,8 @@ This should open a GUI window:
         to the PyPI server.
 
 
-      Confirm that you are running a `version of python that this tutorial supports
-      <install-python>`_.
+      Confirm that you are running a :ref:`version of python that this tutorial supports
+      <install-python>`.
 
       If your version of python is *not* a supported version, you will have to restart
       the tutorial.

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -219,6 +219,26 @@ This should open a GUI window:
        :align: center
        :alt: Hello World Tutorial 1 window, on Windows
 
+  .. admonition:: Invalid requirements or pip unable to connect
+
+
+    You may encounter an error that reads:
+
+
+    ``Unable to install requirements. This may be because one of your
+    requirements is invalid, or because pip was unable to connect
+    to the PyPI server.``
+
+
+    This is likely due to the use of an incompatible version of python (ie 3.13). To rectify this:
+      Go to file manager and delete the venv and helloworld folder as that likely won’t work with the environment’s python version.
+      To fix the version discrepancy, either:
+        Delete the incompatible python version (not advised)
+        Specify the version of python to run the virtual environment in. Example:
+          “py -3.12 -m venv beeware-venv” specifies to use python 3.12.
+      Repeat the earlier steps.
+
+
 Press the close button (or select Quit from the application's menu), and you're
 done! Congratulations - you've just written a standalone, native application
 in Python!

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -228,6 +228,7 @@ This should open a GUI window:
         Unable to install requirements. This may be because one of your
         requirements is invalid, or because pip was unable to connect
         to the PyPI server.
+
       Confirm that you are running a :ref:`version of python that this tutorial supports
       <install-python>`.
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -230,9 +230,9 @@ This should open a GUI window:
         to the PyPI server.
 
 
-      This is likely due to the use of an incompatible version of python (ie 3.13). To rectify this:
+      This is likely due to the use of an incompatible version of python (i.e. 3.13). To rectify this:
 
-      Go to file manager and delete the venv and helloworld folder as that likely won’t work with the environment’s python version.
+      Go to file manager and delete the venv and ``helloworld`` folder as that likely won’t work with the environment’s python version.
       To fix the version discrepancy, either:
 
       * Delete the incompatible python version (not advised)

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -221,9 +221,7 @@ This should open a GUI window:
 
     .. admonition:: Invalid requirements or pip unable to connect
 
-
       You may encounter an error that reads:
-
 
       .. code-block:: doscon
 
@@ -238,9 +236,9 @@ This should open a GUI window:
       To fix the version discrepancy, either:
 
       * Delete the incompatible python version (not advised)
-      
+
       * Specify the version of python to run the virtual environment in. Example:
-        
+
       .. code-block:: doscon
 
         py -3.12 -m venv beeware-venv #specifies to use python 3.12.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I inserted notifications of what to do if an error were to be encountered during the tutorial. It contains a set of instructions on what to do if the message "Unable to install requirements. This may be because one of your requirements is invalid, or because pip was unable to connect to the PyPI server" was encountered
<!--- What problem does this change solve? -->
This solves an issue where the virtual environment is set up with an unsupported version of python (ie 3.13), leading to the resulting error.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
