### PR TITLE
Make description easier to read

### DIFF
--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -161,9 +161,15 @@ This reports the specific icon file (or files) that Briefcase is expecting.
 However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
+
+
+
 Let's provide some actual icons. Download :download:`this icons.zip bundle
-<../resources/icons.zip>`, and unpack it into the root of your project
-directory. After unpacking, your project directory should look something like::
+<../resources/icons.zip>`, and unzip the file. To place the files in the root of your
+helloworld directory, drag the icons.zip files manually to the directory in vsCode.
+Your project directory should look something like::
+
+
 
     beeware-tutorial/
     ├── beeware-venv/

--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -162,8 +162,8 @@ However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
 Let's provide some actual icons. Download :download:`this icons.zip bundle
-<../resources/icons.zip>`, and unzip the file. We can then place the icons
-folder into the root of the helloworld directory. Your project directory should look something like::
+<../resources/icons.zip>`, and unzip the file. We can then place the ``icons``
+folder into the root of the ``helloworld`` directory. Your project directory should look something like::
 
     beeware-tutorial/
     ├── beeware-venv/

--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -161,15 +161,10 @@ This reports the specific icon file (or files) that Briefcase is expecting.
 However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
-
-
-
 Let's provide some actual icons. Download :download:`this icons.zip bundle
 <../resources/icons.zip>`, and unzip the file. To place the files in the root of your
 helloworld directory, drag the icons.zip files manually to the directory in vsCode.
 Your project directory should look something like::
-
-
 
     beeware-tutorial/
     ├── beeware-venv/

--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -162,9 +162,8 @@ However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
 Let's provide some actual icons. Download :download:`this icons.zip bundle
-<../resources/icons.zip>`, and unzip the file. To place the files in the root of your
-helloworld directory, drag the icons.zip files manually to the directory in vsCode.
-Your project directory should look something like::
+<../resources/icons.zip>`, and unzip the file. We can then place the icons
+folder into the root of the helloworld directory. Your project directory should look something like::
 
     beeware-tutorial/
     ├── beeware-venv/

--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -162,8 +162,8 @@ However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
 Let's provide some actual icons. Download :download:`this icons.zip bundle
-<../resources/icons.zip>`, and unzip into the root of the ``helloworld`` directory. After unzipping,
-your project directory should look something like::
+<../resources/icons.zip>`, and unzip into the root of the ``helloworld``
+directory. After unzipping, your project directory should look something like::
 
     beeware-tutorial/
     ├── beeware-venv/

--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -162,8 +162,8 @@ However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
 Let's provide some actual icons. Download :download:`this icons.zip bundle
-<../resources/icons.zip>`, and unzip the file. We can then place the ``icons``
-folder into the root of the ``helloworld`` directory. Your project directory should look something like::
+<../resources/icons.zip>`, and unzip into the root of the ``helloworld`` directory. After unzipping,
+your project directory should look something like::
 
     beeware-tutorial/
     ├── beeware-venv/

--- a/docs/tutorial/topics/custom-icons.rst
+++ b/docs/tutorial/topics/custom-icons.rst
@@ -162,7 +162,7 @@ However, as we haven't provided the actual icon files, the install fails, and
 Briefcase falls back to a default value (the same "gray bee" icon).
 
 Let's provide some actual icons. Download :download:`this icons.zip bundle
-<../resources/icons.zip>`, and unzip into the root of the ``helloworld``
+<../resources/icons.zip>`, and unzip it into the root of your project
 directory. After unzipping, your project directory should look something like::
 
     beeware-tutorial/


### PR DESCRIPTION
This commit edited the part of the text in the customising icons page and made it more clear to read. 

**Text that is unclear/ambiguous**

Original description I am modifying: "Let’s provide some actual icons. Download [this icons.zip bundle](https://docs.beeware.org/en/latest/_downloads/a8f92cddc5b6e0f777b9d9b223d31cce/icons.zip), and **unpack** it into the root of your project directory. **After unpacking, your project directory should look something like:**"

The problem was that I didn't understand what the term "unpack" means and I was concerned that users who encountered this word would be stuck on how to proceed. I also felt that there should be an additional steps on how to place the files into the root directory as I was initially unsure on how to do so when reading the instructions. I felt that there was ambiguity on which directory we should place the files in.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [x ] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
