### PR TITLE
Add note for exiting terminal loop if app window fails to render

### DIFF
--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -91,6 +91,11 @@ the Main Window is closed, the application exits. The Main Window is also the
 window that has the application's menu (if you're on a platform like Windows
 where menu bars are part of the window).
 
+.. admonition:: No Windows?
+    :class: caution
+
+    If your app gets stuck in the terminal without displaying any application windows, press **Ctrl+C** to break the loop and start troubleshooting the issue.
+
 We then add our empty box as the content of the main window, and instruct the
 application to show our window::
 


### PR DESCRIPTION
There are scenarios where a user can end up in a loop with an error early before the main windows render. This change adds an admonition to the documentation, informing users how to exit the loop using `Ctrl+C`.

## What problem does this change solve?
Helps users who encounter errors in the development environment know how to recover from a stuck terminal state.

## Related Issues
N/A

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
