### PR TITLE
Add iOS simulator instructions

### DIFF
--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -19,6 +19,7 @@ pre
 Pre
 px
 runtime
+runtimes
 Runtime
 scaffolded
 Smooooth

--- a/docs/tutorial/tutorial-5/iOS.rst
+++ b/docs/tutorial/tutorial-5/iOS.rst
@@ -3,9 +3,14 @@ Tutorial 5 - Taking it mobile: iOS
 ==================================
 
 To compile iOS applications we'll need Xcode, which is available for free from `the macOS
-App Store <https://apps.apple.com/au/app/xcode/id497799835?mt=12>`__.
+App Store <https://apps.apple.com/au/app/xcode/id497799835?mt=12>`__. Once Xcode is
+installed, launch it from Applications and accept the Xcode License Agreement. Next,
+Xcode will show which Simulator runtimes are built-in, and which Simulator runtimes
+you may download. Select the checkbox next to the iOS Simulator runtime, and then
+click Continue to download and install it.
 
-Once we've got Xcode installed, we can take our application and deploy it as an iOS app.
+Once we've got Xcode and the iOS simulator installed, we can take our application and
+deploy it as an iOS app.
 
 The process of deploying an application to iOS is very similar to the process
 for deploying as a desktop application. First, you run the ``create`` command -


### PR DESCRIPTION
I ran through the tutorial from scratch on macOS with no Xcode installed. After I installed Xcode, I launched it and accepted the license agreement, but I didn't install an iOS simulator. I tried to run `briefcase create iOS`. I got the following error in the build log:

```
           [helloworld] Updating app metadata...                                                                                                                        xcode.py:393
           Setting main module... started                                                                                                                               xcode.py:374
           Setting main module... done                                                                                                                                  xcode.py:374
                                                                                                                                                                        xcode.py:396
           [helloworld] Building Xcode project...                                                                                                                       xcode.py:396
           Building... started                                                                                                                                          xcode.py:397
                                                                                                                                                                   subprocess.py:827
           >>> Running Command:                                                                                                                                    subprocess.py:827
           >>>     xcodebuild build -project '/Users/dyeaw/beeware-tutorial/helloworld/build/helloworld/ios/xcode/Hello World.xcodeproj' -destination              subprocess.py:827
           'platform="iOS Simulator"' -configuration Debug -arch arm64 -sdk iphonesimulator -quiet                                                                                  
           >>> Working Directory:                                                                                                                                  subprocess.py:827
           >>>     /Users/dyeaw/beeware-tutorial/helloworld                                                                                                        subprocess.py:827
[09:55:33] --- xcodebuild: WARNING: Ignoring provided run destination because no scheme was passed.                                                                subprocess.py:195
[09:55:36] /* com.apple.actool.errors */                                                                                                                           subprocess.py:195
           /Users/dyeaw/beeware-tutorial/helloworld/build/helloworld/ios/xcode/HelloWorld/Images.xcassets: error: No available simulator runtimes for platform     subprocess.py:195
           iphonesimulator. SimServiceContext supportedRuntimes=[]                                                                                                                  
           /* com.apple.actool.document.notices */                                                                                                                 subprocess.py:195
           /Users/dyeaw/beeware-tutorial/helloworld/build/helloworld/ios/xcode/HelloWorld/Images.xcassets:./AppIcon.appiconset/[][ipad][76x76][][][1x][][][][]:    subprocess.py:195
           notice: 76x76@1x app icons only apply to iPad apps targeting releases of iOS prior to 10.0.                                                                              
           /* com.apple.actool.compilation-results */                                                                                                              subprocess.py:195
           /Users/dyeaw/beeware-tutorial/helloworld/build/helloworld/ios/xcode/build/Debug-iphonesimulator/Hello World.app/AppIcon60x60@2x.png                     subprocess.py:195
           /Users/dyeaw/beeware-tutorial/helloworld/build/helloworld/ios/xcode/build/Debug-iphonesimulator/Hello World.app/AppIcon76x76@2x~ipad.png                subprocess.py:195
           /Users/dyeaw/beeware-tutorial/helloworld/build/helloworld/ios/xcode/build/Hello World.build/Debug-iphonesimulator/Hello                                 subprocess.py:195
           World.build/assetcatalog_generated_info.plist                                                                                                                            
                                                                                                                                                                   subprocess.py:195
           note: Run script build phase 'Install target specific Python modules' will be run during every build because the option to run the script phase "Based  subprocess.py:195
           on dependency analysis" is unchecked. (in target 'Hello World' from project 'Hello World')                                                                               
           note: Run script build phase 'Sign Python Binary Modules' will be run during every build because the option to run the script phase "Based on           subprocess.py:195
           dependency analysis" is unchecked. (in target 'Hello World' from project 'Hello World')                                                                                  
           ** BUILD FAILED **       
```

I went back and installed the iOS simulator, and then everything worked great. This PR updates the tutorial to give more guidance on steps to take after installing Xcode.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
