### PR TITLE
Bump codespell from v2.4.0 to v2.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
     - id: codespell
       # remove toml extra once Python 3.10 is no longer supported


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.4.0 to v2.4.1 and ran the update against the repo.