### PR TITLE
Bump flake8 from 7.1.1 to 7.1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 7.1.1 to 7.1.2 and ran the update against the repo.