### PR TITLE
Modify install instructions for older Linux releases.

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -120,7 +120,7 @@ Next, install the additional dependencies needed for your operating system:
       Ubuntu or Debian release, the tutorial will be significantly easier.
 
       If you can't, keep an eye out for the additional steps - if you don't follow
-      them, you'll see errors referencing PyGObject or girepository-2.0.
+      them, you'll see errors referencing PyGObject or ``girepository-2.0``.
 
     .. code-block:: console
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -100,11 +100,27 @@ Next, install the additional dependencies needed for your operating system:
     To support local development, you'll need to install some system packages.
     The list of packages required varies depending on your distribution:
 
-    **Ubuntu / Debian**
+    **Ubuntu 24.04 / Debian 13**
 
     ..
       The package list should be the same as in ci.yml and unix-prerequisites.rst in the
       Toga repository.
+
+    .. code-block:: console
+
+      $ sudo apt update
+      $ sudo apt install git build-essential pkg-config python3-dev python3-venv libgirepository-2.0-dev libcairo2-dev gir1.2-gtk-3.0 libcanberra-gtk3-module
+
+    **Ubuntu 22.04 / Debian 11 / Debian 12**
+
+    .. warning::
+
+      Using Ubuntu 22.04, Debian 11 or Debian 12 will require some addition
+      modifications later in the tutorial. If you're able to use a more recent
+      Ubuntu or Debian release, the tutorial will be significantly easier.
+
+      If you can't, keep an eye out for the additional steps - if you don't follow
+      them, you'll see errors referencing PyGObject or girepository-2.0.
 
     .. code-block:: console
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -173,6 +173,25 @@ the project in Developer (or ``dev``) mode:
 
   .. group-tab:: Linux
 
+    .. admonition:: Additional steps on Ubuntu 22.04, Debian 11, and Debian 12
+
+      If you're using Ubuntu 22.04, Debian 11, or Debian 12, you'll need to make some changes
+      to the project that has been generated before you can run it. Open the ``pyproject.toml``
+      file, and make the following changes:
+
+      1. Search for ``# "pygobject < 3.52.1"``. Remove the ``#`` from the start of that line.
+      2. Search for ``# "libgirepository1.0-dev"``. Remove the ``#`` from the start of that line,
+         and add a ``#`` to the line before it (it should say ``"libgirepository-2.0-dev"``)
+      3. Search for ``# "libgirepository-1.0-1"``. Remove the ``#`` from the start of that line,
+         and add a ``#`` to the line before it (it should say ``"libgirepository-2.0-0"``)
+
+      These changes are required because older Debian-based releases don't
+      include libraries that are required by more recent releases of PyGObject.
+      Make sure you've saved the changes to you ``pyproject.toml`` file before
+      you continue!
+
+    Run the following commands:
+
     .. code-block:: console
 
       (beeware-venv) $ cd helloworld


### PR DESCRIPTION
Adds details on install instructions for older Ubuntu and Debian releases.

Fixes #488.

We can't land this until we do a new Briefcase release, because it requires changes to the generated `pyproject.toml.`

Alternatively, we could just say "you can't use Ubuntu 22.04 or Debian 11/12 for this tutorial"....

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
