### PR TITLE
Modify install instructions to allow for PyGObject changes.

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -106,6 +106,13 @@ Next, install the additional dependencies needed for your operating system:
       The package list should be the same as in ci.yml and unix-prerequisites.rst in the
       Toga repository.
 
+    .. warning::
+
+      Using a Debian-based Linux distribution (including Ubuntu) will require
+      some addition modifications later in the tutorial. Keep an eye out for the
+      additional steps - if you don't follow them, you'll see errors referencing
+      PyGObject or ``girepository-2.0``.
+
     .. code-block:: console
 
       $ sudo apt update

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -173,6 +173,39 @@ the project in Developer (or ``dev``) mode:
 
   .. group-tab:: Linux
 
+    .. admonition:: Additional step for Debian-based distributions (including Ubuntu)
+
+      If you're using A Debian-based distribution (including Ubuntu) you'll need
+      to make some changes to the project that has been generated before you can
+      run it. Open the ``pyproject.toml`` file, and look for a reference to
+      ``toga-gtk``. It should be part of a ``requires`` definition, and look
+      something like:
+
+      .. code-block:: toml
+
+        requires = [
+            "toga-gtk~=0.4.7",
+        ]
+
+      Modify this section so it reads:
+
+      .. code-block:: toml
+
+        requires = [
+            "pygobject==3.50.0",
+            "toga-gtk~=0.4.7",
+        ]
+
+      Make sure you've saved the changes to your ``pyproject.toml`` file after
+      you've made this change!
+
+      This changes is required because of a recent change to PyGObject that
+      makes it incompatible with older Debian-based releases. An equivalent
+      fix will be included automatically in a future Briefcase release.
+
+
+    Run the following commands:
+
     .. code-block:: console
 
       (beeware-venv) $ cd helloworld


### PR DESCRIPTION
Adds details on install changes needed on Ubuntu and Debian to accomodate PyGObject 3.52.1 requiring girepository-2.0

Refs #488.

A permanent fix (#489) requires a new Briefcase release.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
