### PR TITLE
Correct a link to the FAQ after the Briefcase docs refactor.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,7 @@ BeeWare is a collection of tools and libraries for building and distributing
 native applications in Python.
 
 For an introduction to the full BeeWare suite, we recommend running the
-`BeeWare Tutorial`_.
-
-.. _BeeWare Tutorial: https://beeware.readthedocs.io/en/latest/
+`BeeWare Tutorial <https://tutorial.beeware.org/>`_.
 
 Community
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,10 +55,10 @@ BeeWare is not a single product, or tool, or library - it's a collection of tool
 libraries, each of which works together to help you write cross platform Python
 applications with a native GUI. It includes:
 
-* `Toga <https://toga.readthedocs.io>`__, a cross platform widget toolkit;
-* `Briefcase <https://briefcase.readthedocs.io>`__, a tool for packaging Python
+* `Toga <https://toga.beeware.org>`__, a cross platform widget toolkit;
+* `Briefcase <https://briefcase.beeware.org>`__, a tool for packaging Python
   projects as distributable artefacts that can be shipped to end users;
-* Libraries (such as `Rubicon ObjC <https://rubicon-objc.readthedocs.io>`__) for
+* Libraries (such as `Rubicon ObjC <https://rubicon-objc.beeware.org>`__) for
   accessing platform-native libraries;
 * Pre-compiled builds of Python that can be used on platforms where official
   Python installers aren't available.

--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -411,7 +411,7 @@ or doing other pre-distribution tasks.
 
     When you're ready to publish a real application, check out the Briefcase
     How-To guide on `Setting up a macOS code signing identity
-    <https://briefcase.readthedocs.io/en/latest/how-to/code-signing/macOS.html>`__.
+    <https://briefcase.beeware.org/en/latest/how-to/code-signing/macOS.html>`__.
 
   .. group-tab:: Linux
 
@@ -564,7 +564,7 @@ or doing other pre-distribution tasks.
 
     When you're ready to publish a real application, check out the Briefcase
     How-To guide on `Setting up a Windows code signing identity
-    <https://briefcase.readthedocs.io/en/latest/how-to/code-signing/windows.html>`__.
+    <https://briefcase.beeware.org/en/latest/how-to/code-signing/windows.html>`__.
 
     Once this step completes, the ``dist`` folder will contain a file named
     ``Hello_World-0.0.1.msi``. If you double click on this installer to run it,

--- a/docs/tutorial/tutorial-7.rst
+++ b/docs/tutorial/tutorial-7.rst
@@ -637,7 +637,7 @@ On desktop platforms (macOS, Windows, Linux), essentially any package on PyPI
 package can be installed into your virtual environment, or added to your app's
 requirements. However, when building an app for mobile or web platforms, `your
 options are slightly limited
-<https://briefcase.readthedocs.io/en/latest/background/faq.html#can-i-use-third-party-python-packages-in-my-app>`__.
+<https://briefcase.beeware.org/en/latest/about/faq.html#can-i-use-third-party-python-packages-in-my-app>`__.
 
 In short; any *pure Python* package (i.e. any package created from a project
 written *only* in Python) can be used without difficulty. Some packages, though,

--- a/docs/tutorial/tutorial-8.rst
+++ b/docs/tutorial/tutorial-8.rst
@@ -362,8 +362,8 @@ So - where to from here?
   application development.
 * If you'd like to know more about how to build complex user interfaces with
   Toga, you can dive into `Toga's documentation
-  <https://toga.readthedocs.io>`__. Toga also has it's own tutorial
+  <https://toga.beeware.org>`__. Toga also has it's own tutorial
   `demonstrating how to use various features of the widget toolkit
-  <https://toga.readthedocs.io/en/latest/tutorial/index.html>`__.
+  <https://toga.beeware.org/en/latest/tutorial/index.html>`__.
 * If you'd like to know more about the capabilities of Briefcase, you can dive
-  into `Briefcase's documentation <https://briefcase.readthedocs.io>`__.
+  into `Briefcase's documentation <https://briefcase.beeware.org>`__.


### PR DESCRIPTION
beeware/briefcase#2335 changed the location of the FAQ; this updates the URL.

Takes this opportunity to update the URLs referring to readthedocs to point at `beeware.org domains, since those are now available, and will be canonical shortly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
