### PR TITLE
Update tutorial-0.rst to mention libgirepository-2.0-dev

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -102,7 +102,8 @@ Next, install the additional dependencies needed for your operating system:
 
     ..
       The package list should be the same as in ci.yml and unix-prerequisites.rst in the
-      Toga repository.
+      Toga repository. You may need to install libgirepository-2.0-dev (note the extra 
+      hyphen!) if you're on a more recent version of these distros.
 
     .. code-block:: console
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -103,7 +103,7 @@ Next, install the additional dependencies needed for your operating system:
     ..
       The package list should be the same as in ci.yml and unix-prerequisites.rst in the
       Toga repository. You may need to install libgirepository-2.0-dev (note the extra 
-      hyphen!) if you're on a more recent version of these distros.
+      hyphen!) if you're on a more recent version of these Linux distributions.
 
     .. code-block:: console
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -102,7 +102,7 @@ Next, install the additional dependencies needed for your operating system:
 
     ..
       The package list should be the same as in ci.yml and unix-prerequisites.rst in the
-      Toga repository. You may need to install libgirepository-2.0-dev (note the extra 
+      Toga repository. You may need to install libgirepository-2.0-dev (note the extra
       hyphen!) if you're on a more recent version of these Linux distributions.
 
     .. code-block:: console


### PR DESCRIPTION
See [PyGObject>=3.51.0 depends on libgirepository 2.0](https://github.com/beeware/toga/issues/3143#top) #3143 . This means following the tutorial leads to errors, confusing for new users.
It makes following the tutorial easier.

## PR Checklist:
- [x ] All new features have been tested
 - No testable new features.
- [ x] All new features have been documented
 - New feature is a documentation change
- [x ] I have read the **CONTRIBUTING.md** file
 - I'd note the [docs contributing guide](https://briefcase.readthedocs.io/en/stable/how-to/contribute-docs.html) linked to [here](https://beeware.org/contributing/process/) is a 404
- [ x] I will abide by the [code of conduct](https://beeware.org/community/behavior/code-of-conduct/)
