### PR TITLE
docs: consistent macOS commands using python3

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -186,7 +186,7 @@ so we have to manually install each package:
     .. code-block:: console
 
       (venv) $ cd beeware
-      (venv) $ python -m pip install -e ".[dev]"
+      (venv) $ python3 -m pip install -e ".[dev]"
 
   .. group-tab:: Linux
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -19,7 +19,7 @@ with the ``beeware-venv`` virtual environment activated, and run:
 
     .. code-block:: console
 
-      (beeware-venv) $ python -m pip install briefcase
+      (beeware-venv) $ python3 -m pip install briefcase
 
   .. group-tab:: Linux
 

--- a/docs/tutorial/tutorial-7.rst
+++ b/docs/tutorial/tutorial-7.rst
@@ -121,7 +121,7 @@ with ``pip``, and then re-running ``briefcase dev``:
 
     .. code-block:: console
 
-      (beeware-venv) $ python -m pip install faker
+      (beeware-venv) $ python3 -m pip install faker
       (beeware-venv) $ briefcase dev
 
     When you enter a name and press the button, you should see a dialog that


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
The macOS commandline examples using Python are inconsistent - while majority uses the usual `python3`, a few of them were left with `python` only.
There is no PR. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
