### PR TITLE
fix: command reference

### DIFF
--- a/docs/tutorial/tutorial-3.rst
+++ b/docs/tutorial/tutorial-3.rst
@@ -350,7 +350,7 @@ application appears.
 Before continuing, close the app. As with previous tutorial steps, you can do
 this by pressing the close button on the application window, by selecting
 Quit/Exit from the application's menu, or by typing **Ctrl+C** in the terminal
-where you ran ``briefcase dev``.
+where you ran ``briefcase run``.
 
 Building your installer
 =======================


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixing the the instruction on how to close the running app. It was referencing `briefcase dev`, but `briefcase run` is actually used in this tutorial step (probably a copy paste error from a different place in the tutorial). 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
