### PR TITLE
Add dark mode CSS for generic content.

### DIFF
--- a/docs/_static/resources/custom.css
+++ b/docs/_static/resources/custom.css
@@ -2,3 +2,8 @@
 .sd-card-title {
     color: var(--color-link);
 }
+
+/* Fix for Pygments not having a dark mode override for "generic content" */
+body[data-theme="dark"] .highlight .go {
+    color: #ccc;
+}


### PR DESCRIPTION
Adds a CSS rule for "generic output", which is how console output is rendered by Pygments. For some reason, pygments doesn't have a dark mode rule for "generic output".

Fixes #550.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
