### PR TITLE
Bump ruff-pre-commit from v0.13.2 to v0.13.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: [--py38-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.13.2
+    rev: v0.13.3
     hooks:
       # Run the linter.
       - id: ruff-check


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.13.2 to v0.13.3 and ran the update against the repo.